### PR TITLE
fix: remove customer data from ClickHouseWriter error logs

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -320,7 +320,7 @@ public class ClickHouseWriter implements DBWriter {
                         ZonedDateTime zonedDateTime = ZonedDateTime.parse((String) value.getObject());
                         BinaryStreamUtils.writeUnsignedInt32(stream, zonedDateTime.toInstant().getEpochSecond());
                     } catch (Exception e) {
-                        LOGGER.error("Error parsing date time string: {}", value.getObject());
+                        LOGGER.error("Error parsing DateTime value for column: {}, fieldType: {}", columnName, value.getFieldType());
                         unsupported = true;
                     }
                 } else {
@@ -373,7 +373,7 @@ public class ClickHouseWriter implements DBWriter {
                             BinaryStreamUtils.writeInt64(stream, seconds);
                         }
                     } catch (Exception e) {
-                        LOGGER.error("Error parsing date time string: {}, exception: {}", value.getObject(), e.getMessage());
+                        LOGGER.error("Error parsing DateTime64 value for column: {}, fieldType: {}, exception: {}", columnName, value.getFieldType(), e.getMessage());
                         unsupported = true;
                     }
                 } else {


### PR DESCRIPTION
## Summary
  - Replace `value.getObject()` with safe metadata (`columnName`, `fieldType`) in two `LOGGER.error()` calls in `ClickHouseWriter.java` (DateTime and DateTime64 parse error paths)
  - Prevents customer Kafka record values from being written to logs
  - Unblocks AppSec approval of the `com.clickhouse.kafka.connect.sink.db.ClickHouseWriter` logger path for external customer logging (LOGGING-4026)

  ## Changes
  - **Line 323** (DateTime): Log `columnName` and `value.getFieldType()` instead of `value.getObject()`
  - **Line 376** (DateTime64): Log `columnName`, `value.getFieldType()`, and `e.getMessage()` instead of `value.getObject()` and `e.getMessage()`