### PR TITLE
INIT-11201: trim sensitive data from default-enabled log paths

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/transforms/KeyToValue.java
+++ b/src/main/java/com/clickhouse/kafka/connect/transforms/KeyToValue.java
@@ -133,7 +133,6 @@ public class KeyToValue<R extends ConnectRecord<R>> implements Transformation<R>
                 newValue.put(f, oldValue.get(f));
             }
         });
-        LOGGER.debug("New schema value: {}", newValue);
         return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(), newValueSchema, newValue, record.timestamp());
     }
 


### PR DESCRIPTION
## Summary
Remove the `LOGGER.debug("New schema value: {}", newValue)` log in `KeyToValue.applyWithSchema`. The line logged the full transformed record value at DEBUG, which can be enabled in support sessions and exposes customer record data.

## Test plan
- [x] `./gradlew clean test` passes locally
- [ ] CI green